### PR TITLE
feat: set automerge type to branch

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:js-lib",
     ":labels(dependencies, chore)",
+    ":automergeBranch",
     ":automergeMinor",
     ":maintainLockFilesWeekly",
     ":widenPeerDependencies",


### PR DESCRIPTION
Reduce noise from opening and self-merging PRs for non-major version updates. If CI fails for a branch, a PR is opened still.