### PR TITLE
chore: remove rebase stale pr configuration

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,7 +10,6 @@
     ":widenPeerDependencies",
     ":semanticCommitTypeAll(chore)"
   ],
-  "rebaseStalePrs": true,
   "prCreation": "not-pending",
   "meteor": {
     "enabled": false


### PR DESCRIPTION
I think this configuration option does not exist. There is a preset however: https://docs.renovatebot.com/presets-default/#rebasestaleprs, but I'm not sure if a switch is needed rn.