### PR TITLE
refactor: update lockfile for dependencies only

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,12 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Useful renovate config rules",
   "extends": [
-    "config:js-lib",
+    "config:base",
     ":labels(dependencies, chore)",
     ":automergeBranch",
     ":automergeMinor",
     ":maintainLockFilesWeekly",
     ":widenPeerDependencies",
+    ":pinDevDependencies",
     ":semanticCommitTypeAll(chore)"
   ],
   "rebaseStalePrs": true,
@@ -15,11 +16,16 @@
   "meteor": {
     "enabled": false
   },
-  "rangeStrategy": "bump",
   "npm": {
     "commitMessageTopic": "{{prettyDepType}} {{depName}}"
   },
   "packageRules": [
+    {
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "rangeStrategy": "update-lockfile"
+    },
     {
       "groupName": "vite dependencies",
       "groupSlug": "vite",
@@ -60,22 +66,6 @@
         "commitlint"
       ],
       "groupName": "all linters"
-    },
-    {
-      "groupName": "nuxt dependencies",
-      "groupSlug": "nuxt-deps",
-      "rangeStrategy": "replace",
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "matchPackageNames": [
-        "nuxt",
-        "@nuxt/schema",
-        "@nuxt/kit",
-        "@nuxt/vite-builder",
-        "@nuxt/webpack-builder",
-        "@nuxt/test-utils"
-      ]
     },
     {
       "groupName": "nuxt core",


### PR DESCRIPTION
Extract the presets `:widenPeerDependencies` and `:pinDevDependencies` out of `config:js-lib` (turning it into `config:base`) and using `update-lockfile` as `rangeStrategy` for dependencies of type `dependencies`. Remove the `nuxt-deps` group.

The idea is to have `dependencies` to use lockfile updates, `devDependencies` to be pinned and peer dependencies to be widened, no matter other grouping logic.
Correct me if I'm wrong, but the overall `rangeStrategy` `bump` is not needed then anymore.